### PR TITLE
Feature/labels to leia

### DIFF
--- a/src/controllers/v1/labelController.js
+++ b/src/controllers/v1/labelController.js
@@ -1,0 +1,78 @@
+import LabelService from '../../services/v1/LabelService.js';
+
+export const getLabels = async (req, res, next) => {
+  try {
+    const userId = req.auth?.payload?.id;
+    const labels = await LabelService.findAllVisible(userId);
+    res.json(labels);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export const getLabelById = async (req, res, next) => {
+  try {
+    const label = await LabelService.findById(req.params.id);
+    if (!label) {
+      const error = new Error('Label not found');
+      error.statusCode = 404;
+      throw error;
+    }
+
+    res.json(label);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createLabel = async (req, res, next) => {
+  try {
+    const labelData = {
+      ...req.body,
+    };
+    const newLabel = await LabelService.create(labelData);
+    res.status(201).json(newLabel);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateLabel = async (req, res, next) => {
+  try {
+    const userId = req.auth?.payload?.id;
+    const role = req.auth?.payload?.role;
+    const label = await LabelService.findById(req.params.id);
+
+    if (!label) {
+      const error = new Error('Label not found');
+      error.statusCode = 404;
+      throw error;
+    }
+
+    if (role !== 'admin' && label.user?.toString() !== userId) {
+      const error = new Error('Unauthorized: You can only update your own labels');
+      error.statusCode = 403;
+      throw error;
+    }
+
+    const updatedLabel = await LabelService.update(req.params.id, req.body);
+    res.json(updatedLabel);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const deleteLabel = async (req, res, next) => {
+  try {
+    const label = await LabelService.findById(req.params.id);
+    if (!label) {
+      const error = new Error('Label not found');
+      error.statusCode = 404;
+      throw error;
+    }
+    await LabelService.delete(req.params.id);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/controllers/v1/leiaController.js
+++ b/src/controllers/v1/leiaController.js
@@ -2,7 +2,7 @@ import LeiaService from '../../services/v1/LeiaService.js';
 import { createLeiaValidator, updateLeiaValidator } from '../../validators/v1/leiaValidator.js';
 import { isNotFound } from '../../utils/helper.js';
 import { isVersionQueryValid, isApiVersionValid } from '../../validators/versionValidator.js';
-import { validateVisibility, validateBoolean } from '../../validators/queryValidator.js';
+import { validateVisibility, validateBoolean, isMongoIdQueryValid } from '../../validators/queryValidator.js';
 
 export const createLeia = async (req, res, next) => {
   try {
@@ -108,7 +108,7 @@ export const getLeiaByNameAndVersion = async (req, res, next) => {
 
 export const getLeiasByQuery = async (req, res, next) => {
   try {
-    const { text, version, apiVersion } = req.query;
+    const { text, version, apiVersion, labelId } = req.query;
 
     if (version && !isVersionQueryValid(version)) {
       const error = new Error('Invalid version format');
@@ -122,12 +122,18 @@ export const getLeiasByQuery = async (req, res, next) => {
       throw error;
     }
 
+    if (labelId && !isMongoIdQueryValid(labelId)) {
+      const error = new Error('Invalid labelId format');
+      error.statusCode = 400;
+      throw error;
+    }
+
     const context = {
       userId: req.auth?.payload?.id,
       role: req.auth?.payload?.role
     };
 
-    const result = await LeiaService.findByQuery(text, version, apiVersion, validateVisibility(req.query.visibility), context);
+    const result = await LeiaService.findByQuery(text, version, apiVersion, validateVisibility(req.query.visibility), context, labelId);
 
     res.json(result);
   } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import personaRoutesV1 from './routes/v1/personaRoutes.js';
 import problemRoutesV1 from './routes/v1/problemRoutes.js';
 import behaviourRoutesV1 from './routes/v1/behaviourRoutes.js';
 import leiaRoutesV1 from './routes/v1/leiaRoutes.js';
+import labelRoutesV1 from './routes/v1/labelRoutes.js';
 import userRoutesV1 from './routes/v1/userRoutes.js';
 import experimentRoutesV1 from './routes/v1/experimentRoutes.js';
 import runnerRoutesV1 from './routes/v1/runnerRoutes.js';
@@ -60,6 +61,7 @@ app.use('/api/v1/personas', personaRoutesV1);
 app.use('/api/v1/problems', problemRoutesV1);
 app.use('/api/v1/behaviours', behaviourRoutesV1);
 app.use('/api/v1/leias', leiaRoutesV1);
+app.use('/api/v1/labels', labelRoutesV1);
 app.use('/api/v1/experiments', experimentRoutesV1);
 app.use('/api/v1/runner', runnerRoutesV1);
 

--- a/src/models/Label.js
+++ b/src/models/Label.js
@@ -1,0 +1,11 @@
+import mongoose, { Schema } from 'mongoose';
+
+const LabelSchema = new Schema({
+  name: { type: String, required: true },  
+  color: { type: String, required: true },  // "#b9482f"
+  secundaryColor: { type: String, required: true },  // "#f9c8b0"
+  user: { type: Schema.Types.ObjectId, ref: 'User' }, // quien la creó
+  isGlobal: { type: Boolean, default: false }, // label del sistema o personal
+});
+
+export default mongoose.model('Label', LabelSchema);

--- a/src/models/Leia.js
+++ b/src/models/Leia.js
@@ -30,6 +30,7 @@ const LeiaSchema = new Schema(
           default: 0,
         },
       },
+      label: { type: mongoose.Schema.Types.ObjectId, ref: 'Label' },
     },
     spec: {
       personaId: {
@@ -53,6 +54,7 @@ const LeiaSchema = new Schema(
       problem: {
         type: Object,
       },
+
     },
     user: {
       type: Schema.Types.ObjectId,

--- a/src/repositories/v1/LabelRepository.js
+++ b/src/repositories/v1/LabelRepository.js
@@ -1,0 +1,37 @@
+import Label from '../../models/Label.js';
+
+class LabelRepository {
+    // READ METHODS
+
+    async find(query = {}) {
+        return await Label.find(query);
+    }
+
+    async findAll() {
+        return await Label.find();
+    }
+
+    async findById(id) {
+        return await Label.findById(id);
+    }
+
+    async findByName(name) {
+        return await Label.findOne({ name });
+    }
+
+    // CREATE/UPDATE METHODS
+
+    async create(labelData) {
+        const label = new Label(labelData);
+        return await label.save();
+    }
+
+    async update(id, labelData) {
+        return await Label.findByIdAndUpdate(id, labelData, { new: true });
+    }
+
+    async delete(id) {
+        return await Label.findByIdAndDelete(id);
+    }
+}               
+export default new LabelRepository();

--- a/src/repositories/v1/LeiaRepository.js
+++ b/src/repositories/v1/LeiaRepository.js
@@ -99,7 +99,7 @@ class LeiaRepository {
       query['metadata.version'] = version;
     }
 
-    return await Leia.find(query).populate('user');
+    return await Leia.find(query).populate('user').populate('metadata.label');
   }
 
   // WRITE METHODS

--- a/src/repositories/v1/LeiaRepository.js
+++ b/src/repositories/v1/LeiaRepository.js
@@ -1,4 +1,5 @@
 import Leia from '../../models/Leia.js';
+import mongoose from 'mongoose';
 import { aggregateFindLatestVersions } from '../../utils/aggregates.js';
 import { applyVisibilityFilters } from '../../utils/entity.js';
 
@@ -76,7 +77,7 @@ class LeiaRepository {
     return await Leia.findOne({ 'metadata.name': name, 'metadata.version': version });
   }
 
-  async findByQuery(text, version, apiVersion, userId = null, visibility = 'all', privileged = false) {
+  async findByQuery(text, version, apiVersion, userId = null, visibility = 'all', privileged = false, labelId) {
     const query = {};
 
     // Apply visibility filters
@@ -91,7 +92,9 @@ class LeiaRepository {
     if (apiVersion) {
       query['apiVersion'] = apiVersion;
     }
-
+    if (labelId) {
+      query['metadata.label'] = new mongoose.Types.ObjectId(labelId);
+    }
     if (version === 'latest') {
       // Pass the complete query to the aggregation
       return await Leia.aggregate(aggregateFindLatestVersions(query));

--- a/src/routes/v1/labelRoutes.js
+++ b/src/routes/v1/labelRoutes.js
@@ -1,0 +1,25 @@
+import express from "express";
+import {
+  createLabel,
+  getLabels,
+  getLabelById,
+  updateLabel,
+  deleteLabel,
+} from "../../controllers/v1/labelController.js";
+import { requireJwtAuthentication, requireAuthentication, requireAdmin } from "../../middlewares/auth.js";
+const router = express.Router();
+
+    //POST
+router.post("/", requireJwtAuthentication, createLabel);
+
+    //GET
+router.get("/", requireAuthentication, getLabels);
+router.get("/:id", requireAuthentication, getLabelById);
+
+    //PUT
+router.put("/:id", requireJwtAuthentication, updateLabel);
+
+    //DELETE
+router.delete("/:id", requireAdmin, deleteLabel);
+
+export default router;

--- a/src/services/v1/LabelService.js
+++ b/src/services/v1/LabelService.js
@@ -1,0 +1,33 @@
+import LabelRepository from '../../repositories/v1/LabelRepository.js';
+
+class LabelService {
+    // READ METHODS
+
+    async findAllVisible(userId) {
+
+        return await LabelRepository.find({ $or: [{ isGlobal: true }, { user: userId }] });
+    }
+
+    async findById(id) {
+        return await LabelRepository.findById(id);
+    }
+
+    async findByName(name) {
+        return await LabelRepository.findByName(name);
+    }
+
+    // CREATE/UPDATE METHODS
+
+    async create(labelData) {
+        return await LabelRepository.create(labelData);
+    }
+
+    async update(id, labelData) {
+        return await LabelRepository.update(id, labelData);
+    }
+
+    async delete(id) {
+        return await LabelRepository.delete(id);
+    }
+}
+    export default new LabelService();

--- a/src/services/v1/LeiaService.js
+++ b/src/services/v1/LeiaService.js
@@ -132,7 +132,7 @@ class LeiaService {
     return leia;
   }
 
-  async findByQuery(text, version, apiVersion, visibility = 'all', context = {}) {
+  async findByQuery(text, version, apiVersion, visibility = 'all', context = {}, labelId) {
     if (version && version !== 'latest') {
       version = getVersionObjectFromString(version);
     }
@@ -143,7 +143,8 @@ class LeiaService {
       apiVersion,
       context.userId,
       visibility,
-      context.role === 'admin' || context.internal
+      context.role === 'admin' || context.internal,
+      labelId
     );
   }
 

--- a/src/utils/aggregates.js
+++ b/src/utils/aggregates.js
@@ -38,8 +38,22 @@ export function aggregateFindLatestVersions(match = {}) {
       },
     },
     {
+      $lookup: {
+        from: 'labels',
+        localField: 'metadata.label',
+        foreignField: '_id',
+        as: 'metadata.label',
+      },
+    },
+    {
       $unwind: {
         path: '$user',
+        preserveNullAndEmptyArrays: true,
+      },
+    },
+    {
+      $unwind: {
+        path: '$metadata.label',
         preserveNullAndEmptyArrays: true,
       },
     },
@@ -69,6 +83,7 @@ export function aggregateFindLatestVersions(match = {}) {
         'user._id': 0,
         'user.__v': 0,
         'user.password': 0,
+        'metadata.label.__v': 0,
       },
     }
   );

--- a/src/validators/queryValidator.js
+++ b/src/validators/queryValidator.js
@@ -21,6 +21,13 @@ export const validateBoolean = (value, defaultValue = false) => {
 };
 
 /**
+ * Validates MongoDB ObjectId query parameters.
+ * @param {string} id - The ObjectId query parameter to validate
+ * @returns {boolean} - True when id is a 24-character hex ObjectId
+ */
+export const isMongoIdQueryValid = (id) => typeof id === 'string' && /^[a-fA-F0-9]{24}$/.test(id);
+
+/**
  * Validates and returns a sanitized process parameter
  * @param {string} process - The process parameter to validate
  * @returns {string|null} - Valid process value ('requirements-elicitation', 'game', 'other') or null if invalid/empty

--- a/src/validators/v1/labelValidator.js
+++ b/src/validators/v1/labelValidator.js
@@ -1,0 +1,16 @@
+import Joi from 'joi';
+
+export const createLabelValidator = Joi.object({
+  name: Joi.string().required(),
+  color: Joi.string().required(),
+  secundaryColor: Joi.string().required(),
+  user: Joi.string().hex().length(24).required(),
+  isGlobal: Joi.boolean().optional(),
+});
+
+export const updateLabelValidator = Joi.object({
+  name: Joi.string().optional(),
+  color: Joi.string().optional(),
+  secundaryColor: Joi.string().optional(),
+  isGlobal: Joi.boolean().optional(),
+});

--- a/src/validators/v1/leiaValidator.js
+++ b/src/validators/v1/leiaValidator.js
@@ -15,6 +15,7 @@ export const createLeiaValidator = Joi.object({
     version: Joi.string()
       .optional()
       .pattern(/^[0-9]+\.[0-9]+\.[0-9]+$/),
+    label: mongoId.optional(),
   }).required(),
   spec: Joi.object({
     persona: Joi.alternatives().try(mongoId, nameVersion).required(),
@@ -30,6 +31,7 @@ export const updateLeiaValidator = Joi.object({
     version: Joi.string()
       .required()
       .pattern(/^[0-9]+\.[0-9]+\.[0-9]+$/),
+    label: mongoId.optional(),
   }).required(),
   spec: Joi.object({
     persona: Joi.alternatives().try(mongoId, nameVersion).required(),


### PR DESCRIPTION
A new labeling system has been implemented and integrated with Leia entities through a refId. Labels are stored in their own collection and include fields such as name, primary color, secondary color, and a boolean flag (isGlobal). The corresponding repository, service, and controller layers have been developed to support full CRUD operations.

The Leia search query parameters have been updated to allow filtering Leia entities by their associated label.

At the moment, each Leia can only have one label. Only admin users are allowed to create global labels, while instructors and advanced users can create labels that are limited to their own session.