### PR TITLE
feat: multiple labels for leia

### DIFF
--- a/src/controllers/v1/leiaController.js
+++ b/src/controllers/v1/leiaController.js
@@ -158,3 +158,29 @@ export const deleteLeiaById = async (req, res, next) => {
     next(err);
   }
 };
+
+export const updateLeiaLabels = async (req, res, next) => {
+  try {
+    const context = {
+      userId: req.auth?.payload?.id,
+      role: req.auth?.payload?.role
+    };
+    const leia = await LeiaService.findById(req.params.id, context);
+    if (context.role !== 'admin' && leia.user.toString() !== context.userId) {
+      const error = new Error('Unauthorized');
+      error.statusCode = 403;
+      throw error;
+    }
+    const labelsIds = req.body.labelsIds;
+    const updatedLeia = await LeiaService.updateById(req.params.id, labelsIds);
+    
+    if (isNotFound(updatedLeia)) {
+      const error = new Error('Leia not found');
+      error.statusCode = 404;
+      throw error;
+    }
+    res.status(200).json(updatedLeia);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/models/Leia.js
+++ b/src/models/Leia.js
@@ -30,7 +30,10 @@ const LeiaSchema = new Schema(
           default: 0,
         },
       },
-      label: { type: mongoose.Schema.Types.ObjectId, ref: 'Label' },
+      labels: [{
+          type: mongoose.Schema.Types.ObjectId,
+          ref: 'Label'
+      }],
     },
     spec: {
       personaId: {

--- a/src/repositories/v1/LeiaRepository.js
+++ b/src/repositories/v1/LeiaRepository.js
@@ -13,6 +13,10 @@ class LeiaRepository {
   async findById(id) {
     return await Leia.findById(id);
   }
+  
+  async findByIdAndUpdate(id, updateData) {
+    return await Leia.findByIdAndUpdate(id, updateData, { new: true}).populate('metadata.labels');
+  }
 
   async findByIdPopulatedUser(id) {
     return await Leia.findById(id).populate('user');
@@ -93,7 +97,11 @@ class LeiaRepository {
       query['apiVersion'] = apiVersion;
     }
     if (labelId) {
-      query['metadata.label'] = new mongoose.Types.ObjectId(labelId);
+      const labelObjectId = new mongoose.Types.ObjectId(labelId);
+      query['$or'] = [
+        { 'metadata.labels': labelObjectId },
+        { 'metadata.label': labelObjectId },
+      ];
     }
     if (version === 'latest') {
       // Pass the complete query to the aggregation
@@ -102,7 +110,7 @@ class LeiaRepository {
       query['metadata.version'] = version;
     }
 
-    return await Leia.find(query).populate('user').populate('metadata.label');
+    return await Leia.find(query).populate('user').populate('metadata.labels');
   }
 
   // WRITE METHODS

--- a/src/routes/v1/leiaRoutes.js
+++ b/src/routes/v1/leiaRoutes.js
@@ -7,7 +7,8 @@ import {
   getLeiasByQuery,
   getLeiaByNameAndVersion,
   getLeiasByName,
-  deleteLeiaById
+  deleteLeiaById,
+  updateLeiaLabels
 } from '../../controllers/v1/leiaController.js';
 import { requireJwtAuthentication, requireAuthentication } from '../../middlewares/auth.js';
 
@@ -16,6 +17,9 @@ const router = express.Router();
 // POST
 router.post('/version', requireJwtAuthentication, createNewLeiaVersion);
 router.post('/', requireJwtAuthentication, createLeia);
+
+// PATCH
+router.patch('/:id/labels', requireJwtAuthentication, updateLeiaLabels);
 
 // GET
 router.get('/exists/:name', requireAuthentication, existsLeiaByName);

--- a/src/services/v1/LeiaService.js
+++ b/src/services/v1/LeiaService.js
@@ -361,6 +361,16 @@ class LeiaService {
     const deletedLeia = await LeiaRepository.deleteById(id);
     return deletedLeia;
   }
-}
 
+  async updateById(id, updateData) {
+    const leia = await LeiaRepository.findById(id);
+    if (!leia) {
+      const error = new Error('Leia not found');
+      error.statusCode = 404;
+      throw error;
+    }
+    const updatedLeia = await LeiaRepository.findByIdAndUpdate(id, { $set: { 'metadata.labels': updateData } });
+    return updatedLeia;
+}
+}
 export default new LeiaService();

--- a/src/utils/aggregates.js
+++ b/src/utils/aggregates.js
@@ -30,6 +30,22 @@ export function aggregateFindLatestVersions(match = {}) {
       $replaceRoot: { newRoot: '$latest' },
     },
     {
+      $addFields: {
+        'metadata.labels': {
+          $setUnion: [
+            { $ifNull: ['$metadata.labels', []] },
+            {
+              $cond: [
+                { $ifNull: ['$metadata.label', false] },
+                ['$metadata.label'],
+                [],
+              ],
+            },
+          ],
+        },
+      },
+    },
+    {
       $lookup: {
         from: 'users',
         localField: 'user',
@@ -40,20 +56,14 @@ export function aggregateFindLatestVersions(match = {}) {
     {
       $lookup: {
         from: 'labels',
-        localField: 'metadata.label',
+        localField: 'metadata.labels',
         foreignField: '_id',
-        as: 'metadata.label',
+        as: 'metadata.labels',
       },
     },
     {
       $unwind: {
         path: '$user',
-        preserveNullAndEmptyArrays: true,
-      },
-    },
-    {
-      $unwind: {
-        path: '$metadata.label',
         preserveNullAndEmptyArrays: true,
       },
     },
@@ -83,7 +93,7 @@ export function aggregateFindLatestVersions(match = {}) {
         'user._id': 0,
         'user.__v': 0,
         'user.password': 0,
-        'metadata.label.__v': 0,
+        'metadata.labels.__v': 0,
       },
     }
   );

--- a/src/validators/v1/leiaValidator.js
+++ b/src/validators/v1/leiaValidator.js
@@ -15,7 +15,7 @@ export const createLeiaValidator = Joi.object({
     version: Joi.string()
       .optional()
       .pattern(/^[0-9]+\.[0-9]+\.[0-9]+$/),
-    label: mongoId.optional(),
+    labels: Joi.array().items(Joi.string().hex().length(24)).optional(),
   }).required(),
   spec: Joi.object({
     persona: Joi.alternatives().try(mongoId, nameVersion).required(),
@@ -31,7 +31,7 @@ export const updateLeiaValidator = Joi.object({
     version: Joi.string()
       .required()
       .pattern(/^[0-9]+\.[0-9]+\.[0-9]+$/),
-    label: mongoId.optional(),
+    labels: Joi.array().items(Joi.string().hex().length(24)).optional(),
   }).required(),
   spec: Joi.object({
     persona: Joi.alternatives().try(mongoId, nameVersion).required(),


### PR DESCRIPTION
* Multiple Labels for each LEIA:
-> Updated the model of LEIA for it to be an Array of LabelsId
-> Updated the LeiaRepository: populate now is change from metadata.label to metadata.labels, and fixed the filter for the LeiaSearch
-> Updated the validatorLeia to expect an array of Ids in the labels field
-> Updated the aggregation, fusion the deprecated metadata.label into the new one

* Managing Labels of LEIA:
-> Added new route to patch the Labels field of the LEIA
-> New Controller updateLeiaLabels that ensures that the user is wether the owner of the leia or an admin to modify the labels
-> New Service that passes the field labelds that is going to be changed
-> New repository function to find the id of the Leia and update the indicated field
