### PR TITLE
fix(problem-chat): forward fileIds on chat messages

### DIFF
--- a/src/controllers/v1/runnerController.js
+++ b/src/controllers/v1/runnerController.js
@@ -191,8 +191,8 @@ export const uploadProblemChatFile = async (req, res, next) => {
 export const sendProblemChatMessage = async (req, res, next) => {
   try {
     const { chatId } = req.params;
-    const { message, tools, toolResults } = req.body;
-    const result = await RunnerService.sendProblemChatMessage(chatId, { message, tools, toolResults });
+    const { message, tools, toolResults, fileIds } = req.body;
+    const result = await RunnerService.sendProblemChatMessage(chatId, { message, tools, toolResults, fileIds });
     res.json(result);
   } catch (err) {
     next(err);


### PR DESCRIPTION
Part of the fix for the attached PDF not reaching the model. `sendProblemChatMessage` now forwards the client's `fileIds` to the runner (alongside message/tools/toolResults), so the runner can attach the uploaded PDF reliably. Pairs with leia-runner and leia-designer-frontend PRs.