### PR TITLE
feat: background supervisor LLM

### DIFF
--- a/src/validators/v1/leiaValidator.js
+++ b/src/validators/v1/leiaValidator.js
@@ -8,6 +8,24 @@ const nameVersion = Joi.object({
     .pattern(/^[0-9]+\.[0-9]+\.[0-9]+$/),
 });
 
+// Per-LEIA background supervisor, authored by the instructor. Optional; rides
+// in the LEIA spec and is denormalized to the workbench (leia.leia.spec).
+const supervisorConfig = Joi.object({
+  enabled: Joi.boolean().optional(),
+  instructions: Joi.string().allow('').optional(),
+  categories: Joi.array().items(Joi.string()).optional(),
+  sensitivity: Joi.string().valid('low', 'medium', 'high').optional(),
+  cadence: Joi.string().valid('everyN', 'onFinish').optional(),
+  everyN: Joi.number().integer().min(1).max(50).optional(),
+  intervene: Joi.boolean().optional(),
+  interveneInstructions: Joi.string().allow('').optional(),
+  // The supervisor runs on OpenAI with its own key (independent of the LEIA's
+  // provider): the chosen apiKey + its owning user, resolved at runtime (BYOK).
+  apiKeyId: Joi.string().hex().length(24).optional(),
+  apiKeyRequesterId: Joi.string().hex().length(24).optional(),
+  model: Joi.string().allow('', null).optional(),
+}).optional();
+
 export const createLeiaValidator = Joi.object({
   apiVersion: Joi.string().required().valid('v1'),
   metadata: Joi.object({
@@ -21,6 +39,7 @@ export const createLeiaValidator = Joi.object({
     persona: Joi.alternatives().try(mongoId, nameVersion).required(),
     behaviour: Joi.alternatives().try(mongoId, nameVersion).required(),
     problem: Joi.alternatives().try(mongoId, nameVersion).required(),
+    supervisorConfig,
   }).required(),
 });
 
@@ -37,6 +56,7 @@ export const updateLeiaValidator = Joi.object({
     persona: Joi.alternatives().try(mongoId, nameVersion).required(),
     behaviour: Joi.alternatives().try(mongoId, nameVersion).required(),
     problem: Joi.alternatives().try(mongoId, nameVersion).required(),
+    supervisorConfig,
   }).required(),
 });
 


### PR DESCRIPTION
Allows an optional per-LEIA supervisorConfig in the LEIA spec validator (enabled, instructions, categories, sensitivity, cadence/everyN, intervene, dedicated OpenAI apiKey/requester/model).