### PR TITLE
fix: restore Designer backend startup

### DIFF
--- a/src/controllers/v1/experimentController.js
+++ b/src/controllers/v1/experimentController.js
@@ -49,6 +49,15 @@ export const getAllExperiments = async (req, res, next) => {
   }
 };
 
+export const checkExperimentNameExists = async (req, res, next) => {
+  try {
+    const exists = await ExperimentService.checkNameExists(req.params.name);
+    res.json({ exists });
+  } catch (err) {
+    next(err);
+  }
+};
+
 export const getAllExperimentsByUser = async (req, res, next) => {
   try {
     const visibility = validateVisibility(req.query.visibility);

--- a/src/routes/v1/experimentRoutes.js
+++ b/src/routes/v1/experimentRoutes.js
@@ -11,7 +11,7 @@ import {
   getAllExperimentsByUser,
   deleteExperimentById,
   createExperimentReplication,
-  
+  checkExperimentNameExists,
 } from '../../controllers/v1/experimentController.js';
 import { requireJwtAuthentication, requireAuthentication, requireAdmin } from '../../middlewares/auth.js';
 

--- a/tests/experimentRoutes.test.js
+++ b/tests/experimentRoutes.test.js
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'vitest';
+import experimentRoutes from '../src/routes/v1/experimentRoutes.js';
+
+describe('experiment routes', () => {
+  test('loads the route module without unresolved handlers', () => {
+    expect(experimentRoutes).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes the pre environment H10 crash caused by experimentRoutes referencing checkExperimentNameExists without importing or defining it. Restores the controller handler, imports it in the router, and adds a route-module startup regression test. Validation: lint passes, 8 tests pass, and the route module imports successfully.