### PR TITLE
fix: handle missing Auth user profiles

### DIFF
--- a/src/utils/authClient.js
+++ b/src/utils/authClient.js
@@ -12,6 +12,12 @@ export const getUserProfileFromAuthService = async (userId) => {
     });
     return response.data;
   } catch (error) {
+    // Designer resources can outlive their Auth user. Keep the stored owner ID
+    // in that case so the resource remains readable and ownership checks work.
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return null;
+    }
+
     console.error(`Error fetching user ${userId} from Auth Service:`, error.message);
     return null;
   }

--- a/tests/authClient.test.js
+++ b/tests/authClient.test.js
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import axios from 'axios';
+import { getUserProfileFromAuthService, populateUserInEntity } from '../src/utils/authClient.js';
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    isAxiosError: vi.fn()
+  }
+}));
+
+describe('Auth client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AUTH_SERVICE_URL = 'https://auth.example.test';
+    process.env.INTERN_TOKEN = 'internal-token';
+  });
+
+  test('returns an existing Auth profile', async () => {
+    const profile = { id: 'user-1', email: 'user@example.test', role: 'instructor' };
+    axios.get.mockResolvedValue({ data: profile });
+
+    await expect(getUserProfileFromAuthService('user-1')).resolves.toEqual(profile);
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://auth.example.test/api/v1/users/intern/user-1',
+      { headers: { 'x-intern-token': 'internal-token' } }
+    );
+  });
+
+  test('treats a missing Auth profile as an expected stale reference', async () => {
+    const error = { message: 'Request failed with status code 404', response: { status: 404 } };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.get.mockRejectedValue(error);
+    axios.isAxiosError.mockReturnValue(true);
+
+    await expect(getUserProfileFromAuthService('deleted-user')).resolves.toBeNull();
+    expect(consoleError).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
+  test('keeps logging actual Auth service failures', async () => {
+    const error = { message: 'Service unavailable', response: { status: 503 } };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    axios.get.mockRejectedValue(error);
+    axios.isAxiosError.mockReturnValue(true);
+
+    await expect(getUserProfileFromAuthService('user-1')).resolves.toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error fetching user user-1 from Auth Service:',
+      'Service unavailable'
+    );
+
+    consoleError.mockRestore();
+  });
+
+  test('preserves the stored owner ID when its Auth profile no longer exists', async () => {
+    axios.get.mockRejectedValue({ message: 'Not found', response: { status: 404 } });
+    axios.isAxiosError.mockReturnValue(true);
+
+    await expect(populateUserInEntity({ id: 'resource-1', user: 'deleted-user' })).resolves.toEqual({
+      id: 'resource-1',
+      user: 'deleted-user'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- treat a 404 from the internal Auth user endpoint as a stale owner reference
- preserve the stored user ID so Designer resources remain readable and ownership checks continue to work
- continue logging non-404 Auth service failures
- add coverage for existing, missing, and unavailable Auth profiles

## Validation
- npm test -- --run
- npm run lint